### PR TITLE
Add Medoid clusterer and distance measure

### DIFF
--- a/LICENCE.md
+++ b/LICENCE.md
@@ -1,0 +1,28 @@
+
+Copyright (c) 2015, the Dart project authors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of Google Inc. nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/lib/clusterers.dart
+++ b/lib/clusterers.dart
@@ -1,0 +1,154 @@
+// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+library nectar.clusterers;
+
+import 'dart:math';
+
+/// K Medoids has a higher computational cost than k-means but returns actual
+/// items, and can work with non-euclidan distance measures
+/// Partitioning Around Medoids, Kaufmann & Rousseeuw 1987 is the original
+/// The implementation here is similar to the one outlined in:
+/// https://en.wikipedia.org/wiki/K-medoids
+class KMedoids {
+  List<DataItem> _data;
+  List<Cluster> clusters = [];
+
+  KMedoids(this._data, [int clusterCount]) {
+    if (clusterCount == null) {
+      clusterCount = sqrt(_data.length/2).ceil();
+    }
+    _init(clusterCount);
+  }
+
+  _init(int clusterCount) {
+    _data.shuffle();
+
+    // Assign the clusters
+    for (int i = 0; i < clusterCount; i++) {
+      clusters.add(new Cluster(_data[i], [_data[i]]));
+    }
+
+    // Assign the rest of the data points with minimum distance
+    for (int i = clusterCount; i < _data.length; i++) {
+      _findNearestCluster(_data[i]).dataItems.add(_data[i]);
+    }
+  }
+
+  Cluster _findNearestCluster(DataItem item) {
+    List<double> distances = clusters.map(
+      (c) => c.medoid.computeDistanceTo(item)).toList();
+
+    int minI = -1;
+    double minSeen = double.MAX_FINITE;
+
+    for (int i = 0; i < distances.length; i++) {
+      if (distances[i] < minSeen) {
+        minSeen = distances[i];
+        minI = i;
+      }
+    }
+    return clusters[minI];
+  }
+
+  bool step() {
+    double startingCost = cost;
+    for (Cluster c1 in clusters) {
+      for (Cluster c2 in clusters) {
+        for (DataItem d in c2.dataItems.toList()) {
+          if (c1.medoid == d || c2.medoid == d) continue;
+
+        	double beforeSwap = cost;
+          DataItem exchanged = _swap(c1, c2, d);
+        	double afterSwap = cost;
+
+          if (afterSwap > beforeSwap) {
+            // If the swap made things worse, undo
+            _swap(c1, c2, exchanged);
+          }
+        }
+      }
+    }
+
+    // Wipe the clusters
+    List<DataItem> medoids = [];
+
+    for (Cluster c in clusters) {
+      c.dataItems.clear();
+      c.dataItems.add(c.medoid);
+      medoids.add(c.medoid);
+    }
+
+    for (DataItem di in _data) {
+      if (medoids.contains(di)) continue;
+      _findNearestCluster(di).dataItems.add(di);
+    }
+
+    double finalCost = cost;
+
+    if (finalCost < startingCost) return true; // Improvement
+    if (finalCost - startingCost > 0.000001) throw "Things got worse!";
+    return false; // No change, we're done here
+  }
+
+  /// Swap the passed data item in cluster 2 to medoid of c1
+  /// Returning the item that was displaced
+  DataItem _swap(Cluster c1, Cluster c2, DataItem d2) {
+    if (c2.medoid == d2) throw "Can't swap out a mediod";
+
+    DataItem d1 = c1.medoid;
+
+    c1.medoid = d2;
+    c1.dataItems.remove(d1);
+    c1.dataItems.add(d2);
+
+    c2.dataItems.remove(d2);
+    c2.dataItems.add(d1);
+
+    return d1;
+  }
+
+  bool isMedoid(DataItem d) => clusters.any((c) => c.medoid == d);
+
+  // TODO: This is expensive, we should probably be caching the x->y cost
+  // computations
+  double get cost => clusters.fold(0.0, (d, c) => d + c.cost);
+}
+
+class DataItem {
+  final dynamic data;
+  final dynamic distanceMeasure;
+
+  const DataItem(this.data, this.distanceMeasure);
+
+  double computeDistanceTo(dynamic other) => distanceMeasure(this, other);
+
+  String toString() {
+    return data.toString();
+  }
+}
+
+class Cluster {
+  DataItem medoid;
+  List<DataItem> dataItems;
+
+  Cluster(this.medoid, this.dataItems);
+
+  double get cost {
+    double costAcc = 0.0;
+    for (DataItem item in dataItems) {
+      costAcc += item.computeDistanceTo(medoid);
+    }
+    return costAcc;
+  }
+
+  String toString() {
+    StringBuffer sb = new StringBuffer();
+    sb.write("Medoid: $medoid\n");
+    sb.write("Data: $dataItems\n");
+
+    return sb.toString();
+  }
+
+}

--- a/lib/distance_measures.dart
+++ b/lib/distance_measures.dart
@@ -1,0 +1,18 @@
+// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+library nectar.distance_measures;
+
+double jaccardDistance(Set a, Set b) {
+  return 1 - _jaccardSimilarityCoefficent(a, b);
+}
+
+/// Precise by slow implementation of Jaccard Similarilty Coefficent
+/// https://en.wikipedia.org/wiki/Jaccard_index
+double _jaccardSimilarityCoefficent(Set a, Set b) {
+  int unionLength = a.union(b).length;
+  int intersectLength = a.intersection(b).length;
+
+  return intersectLength / unionLength;
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,7 @@
+name: nectar
+version: 0.0.1
+description: Data manipulation tools for Dart
+# dependencies:
+  # cli_util: any
+dev_dependencies:
+  test: '>=0.12.0 <0.13.0'

--- a/test/all.dart
+++ b/test/all.dart
@@ -1,0 +1,11 @@
+// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+library nectar.test_all;
+
+import 'distance_measures_test.dart' as distances;
+
+main() {
+  distances.main();
+}

--- a/test/distance_measures_test.dart
+++ b/test/distance_measures_test.dart
@@ -1,0 +1,46 @@
+// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+library nectar.distance_measures.test;
+
+import 'package:test/test.dart';
+import 'package:nectar/distance_measures.dart';
+
+main() {
+  test('testEqualPoints', () {
+    expect(jaccardDistance(
+      new Set()..addAll([0, 1, 2]),
+      new Set()..addAll([0, 1, 2])), 0);
+  });
+
+  test('half', () {
+    expect(jaccardDistance(
+      new Set()..addAll([0, 1]),
+      new Set()..addAll([0, 1, 2, 3])), 0.5);
+  });
+
+  test('quarter', () {
+    expect(jaccardDistance(
+      new Set()..addAll([0]),
+      new Set()..addAll([0, 1, 2, 3])), 0.75);
+  });
+
+  test('max', () {
+    expect(jaccardDistance(
+      new Set()..addAll([10]),
+      new Set()..addAll([0, 1, 2, 3])), 1);
+  });
+
+  test('maxEmpty', () {
+    expect(jaccardDistance(
+      new Set(),
+      new Set()..addAll([0, 1, 2, 3])), 1);
+  });
+
+  test('maxBothEmpty', () {
+    expect(jaccardDistance(new Set(), new Set()).isNaN, true);
+  });
+
+
+}


### PR DESCRIPTION
@danrubel PTAL

This adds the basic clustering and distance algorithm. 

It's slightly complicated by Jaccard being both expensive and non-Euclidean so we're using a comparatively expensive k-medoids as opposed to k-means algorithm. This is a fairly naive implementation that should scale up to the kind of sizes we need for analysis server stack trace clustering, but may well need to be replaced for larger scale models.
