### PR TITLE
NaN fix

### DIFF
--- a/lib/clusterers.dart
+++ b/lib/clusterers.dart
@@ -63,7 +63,7 @@ class KMedoids {
           DataItem exchanged = _swap(c1, c2, d);
         	double afterSwap = cost;
 
-          if (afterSwap > beforeSwap) {
+          if (afterSwap.isNaN || afterSwap > beforeSwap) {
             // If the swap made things worse, undo
             _swap(c1, c2, exchanged);
           }

--- a/lib/clusterers.dart
+++ b/lib/clusterers.dart
@@ -88,7 +88,9 @@ class KMedoids {
     double finalCost = cost;
 
     if (finalCost < startingCost) return true; // Improvement
-    if (finalCost - startingCost > 0.000001) throw "Things got worse!";
+    if (finalCost - startingCost > 0.000001) {
+      throw "Invariant check failed - clustering got worse. finalCost: $finalCost startingCost: $startingCost";
+    }
     return false; // No change, we're done here
   }
 


### PR DESCRIPTION
TBR: @bwilkerson @danrubel 

Rare conditions were causing the cost function to become undefined. This allows the clustered to pass through these states and introduce steps that caused the clustering to regress. This resulting in the invariant trap aborting the clustering.
